### PR TITLE
Reduce GC objects count

### DIFF
--- a/insane.go
+++ b/insane.go
@@ -147,7 +147,7 @@ type decoder struct {
 	id        int
 	buf       []byte
 	root      Root
-	nodePool  []*Node
+	nodePool  []Node
 	nodeCount int
 }
 
@@ -214,9 +214,9 @@ func (d *decoder) decode(json string, shouldReset bool) (*Node, error) {
 	nodePoolLen := len(nodePool)
 	nodes := d.nodeCount
 
-	root := nodePool[nodes]
+	root := &nodePool[nodes]
 	root.parent = nil
-	curNode := nodePool[nodes]
+	curNode := &nodePool[nodes]
 	topNode := root.parent
 
 	c := byte('i') // i means insane
@@ -243,14 +243,14 @@ decodeObject:
 	}
 
 	if c == '}' {
-		curNode.next = nodePool[nodes]
+		curNode.next = &nodePool[nodes]
 		curNode = curNode.next
 		nodes++
 
 		curNode.bits = hellBitEnd
 		curNode.parent = topNode
 
-		topNode.next = nodePool[nodes]
+		topNode.next = &nodePool[nodes]
 		topNode = topNode.parent
 
 		goto pop
@@ -314,7 +314,7 @@ decodeObject:
 		return nil, insaneErr(ErrExpectedObjectFieldSeparator, json, o)
 	}
 
-	curNode.next = nodePool[nodes]
+	curNode.next = &nodePool[nodes]
 	curNode = curNode.next
 	nodes++
 
@@ -363,14 +363,14 @@ decodeArray:
 	}
 
 	if c == ']' {
-		curNode.next = nodePool[nodes]
+		curNode.next = &nodePool[nodes]
 		curNode = curNode.next
 		nodes++
 
 		curNode.bits = hellBitArrayEnd
 		curNode.parent = topNode
 
-		topNode.next = nodePool[nodes]
+		topNode.next = &nodePool[nodes]
 		topNode = topNode.parent
 
 		goto pop
@@ -390,7 +390,7 @@ decodeArray:
 		}
 	}
 
-	topNode.nodes = append(topNode.nodes, nodePool[nodes])
+	topNode.nodes = append(topNode.nodes, &nodePool[nodes])
 decode:
 	// skip wc
 	c = json[o]
@@ -411,7 +411,7 @@ decode:
 			return nil, insaneErr(ErrExpectedObjectField, json, o)
 		}
 
-		curNode.next = nodePool[nodes]
+		curNode.next = &nodePool[nodes]
 		curNode = curNode.next
 		nodes++
 
@@ -429,7 +429,7 @@ decode:
 		if o == l {
 			return nil, insaneErr(ErrExpectedValue, json, o)
 		}
-		curNode.next = nodePool[nodes]
+		curNode.next = &nodePool[nodes]
 		curNode = curNode.next
 		nodes++
 
@@ -465,7 +465,7 @@ decode:
 			}
 		}
 
-		curNode.next = nodePool[nodes]
+		curNode.next = &nodePool[nodes]
 		curNode = curNode.next
 		nodes++
 
@@ -480,7 +480,7 @@ decode:
 		}
 		o += 3
 
-		curNode.next = nodePool[nodes]
+		curNode.next = &nodePool[nodes]
 		curNode = curNode.next
 		nodes++
 
@@ -493,7 +493,7 @@ decode:
 		}
 		o += 4
 
-		curNode.next = nodePool[nodes]
+		curNode.next = &nodePool[nodes]
 		curNode = curNode.next
 		nodes++
 
@@ -506,7 +506,7 @@ decode:
 		}
 		o += 3
 
-		curNode.next = nodePool[nodes]
+		curNode.next = &nodePool[nodes]
 		curNode = curNode.next
 		nodes++
 
@@ -521,7 +521,7 @@ decode:
 			return nil, insaneErr(ErrExpectedValue, json, o)
 		}
 
-		curNode.next = nodePool[nodes]
+		curNode.next = &nodePool[nodes]
 		curNode = curNode.next
 		nodes++
 
@@ -809,7 +809,7 @@ getArray:
 }
 
 func (d *decoder) getNode() *Node {
-	node := d.nodePool[d.nodeCount]
+	node := &d.nodePool[d.nodeCount]
 	d.nodeCount++
 	if d.nodeCount > len(d.nodePool)-16 {
 		d.expandPool()
@@ -1803,16 +1803,13 @@ func (n *Node) getIndex() int {
 // ******************** //
 
 func (d *decoder) initPool() {
-	d.nodePool = make([]*Node, StartNodePoolSize, StartNodePoolSize)
-	for i := 0; i < StartNodePoolSize; i++ {
-		d.nodePool[i] = &Node{}
-	}
+	d.nodePool = make([]Node, StartNodePoolSize, StartNodePoolSize)
 }
 
-func (d *decoder) expandPool() []*Node {
+func (d *decoder) expandPool() []Node {
 	c := cap(d.nodePool)
 	for i := 0; i < c; i++ {
-		d.nodePool = append(d.nodePool, &Node{})
+		d.nodePool = append(d.nodePool, Node{})
 	}
 
 	return d.nodePool

--- a/insane.go
+++ b/insane.go
@@ -809,13 +809,13 @@ getArray:
 }
 
 func (d *decoder) getNode() *Node {
-	node := &d.nodePool[d.nodeCount]
+	last := d.nodeCount
 	d.nodeCount++
 	if d.nodeCount > len(d.nodePool)-16 {
 		d.expandPool()
 	}
 
-	return node
+	return &d.nodePool[last]
 }
 
 func (n *Node) DigStrict(path ...string) (*StrictNode, error) {

--- a/insane.go
+++ b/insane.go
@@ -1803,15 +1803,12 @@ func (n *Node) getIndex() int {
 // ******************** //
 
 func (d *decoder) initPool() {
-	d.nodePool = make([]Node, StartNodePoolSize, StartNodePoolSize)
+	d.nodePool = make([]Node, StartNodePoolSize)
 }
 
 func (d *decoder) expandPool() []Node {
 	c := cap(d.nodePool)
-	for i := 0; i < c; i++ {
-		d.nodePool = append(d.nodePool, Node{})
-	}
-
+	d.nodePool = append(d.nodePool, make([]Node, c)...)
 	return d.nodePool
 }
 


### PR DESCRIPTION
It reduces the number of objects in the heap.

To test the number of objects in the heap I wrote the following code in the BenchmarkFair func:

```go
	memOld := runtime.MemStats{}
	runtime.ReadMemStats(&memOld)
	defer func() {
		memNew := runtime.MemStats{}
		runtime.ReadMemStats(&memNew)
		b.Logf("HeapObjects=%v; HeapAlloc=%v\n", memNew.HeapObjects-memOld.HeapObjects, memNew.HeapAlloc-memOld.HeapAlloc)
	}()
```

old: `insane_perf_test.go:134: HeapObjects=140189; HeapAlloc=8590888`
new: `insane_perf_test.go:134: HeapObjects=72100; HeapAlloc=7133104`

And it also slightly increases performance:

```
$ benchstat -table .fullname old.txt new.txt
.fullname: Fair/complex-stable-flavor|complex-8
                                     │   old.txt   │              new.txt               │
                                     │   sec/op    │   sec/op     vs base               │
Fair/complex-stable-flavor|complex-8   1.121m ± 1%   1.113m ± 1%  -0.68% (p=0.007 n=10)

                                     │   old.txt    │               new.txt               │
                                     │     B/s      │     B/s       vs base               │
Fair/complex-stable-flavor|complex-8   1.069Gi ± 1%   1.076Gi ± 1%  +0.68% (p=0.007 n=10)

                                     │   old.txt    │            new.txt             │
                                     │     B/op     │     B/op      vs base          │
Fair/complex-stable-flavor|complex-8   1.852Ki ± 1%   1.846Ki ± 1%  ~ (p=0.288 n=10)

                                     │  old.txt   │            new.txt             │
                                     │ allocs/op  │ allocs/op   vs base            │
Fair/complex-stable-flavor|complex-8   32.00 ± 0%   32.00 ± 0%  ~ (p=1.000 n=10) ¹
¹ all samples are equal

.fullname: Fair/complex-chaotic-flavor|complex-8
                                      │   old.txt   │            new.txt            │
                                      │   sec/op    │   sec/op     vs base          │
Fair/complex-chaotic-flavor|complex-8   279.9µ ± 1%   279.4µ ± 1%  ~ (p=0.481 n=10)

                                      │   old.txt    │            new.txt             │
                                      │     B/s      │     B/s       vs base          │
Fair/complex-chaotic-flavor|complex-8   283.1Mi ± 1%   283.7Mi ± 1%  ~ (p=0.481 n=10)

                                      │   old.txt    │             new.txt              │
                                      │     B/op     │     B/op      vs base            │
Fair/complex-chaotic-flavor|complex-8   39.81Ki ± 0%   39.81Ki ± 0%  ~ (p=1.000 n=10) ¹
¹ all samples are equal

                                      │   old.txt   │             new.txt             │
                                      │  allocs/op  │  allocs/op   vs base            │
Fair/complex-chaotic-flavor|complex-8   1.532k ± 0%   1.532k ± 0%  ~ (p=1.000 n=10) ¹
¹ all samples are equal

.fullname: Fair/get-stable-flavor|get-8
                             │   old.txt   │            new.txt            │
                             │   sec/op    │   sec/op     vs base          │
Fair/get-stable-flavor|get-8   440.9n ± 1%   442.1n ± 1%  ~ (p=0.811 n=10)

                             │   old.txt    │            new.txt             │
                             │     B/s      │     B/s       vs base          │
Fair/get-stable-flavor|get-8   1.327Ti ± 1%   1.323Ti ± 1%  ~ (p=0.853 n=10)

                             │  old.txt   │            new.txt             │
                             │    B/op    │    B/op     vs base            │
Fair/get-stable-flavor|get-8   0.000 ± 0%   0.000 ± 0%  ~ (p=1.000 n=10) ¹
¹ all samples are equal

                             │  old.txt   │            new.txt             │
                             │ allocs/op  │ allocs/op   vs base            │
Fair/get-stable-flavor|get-8   0.000 ± 0%   0.000 ± 0%  ~ (p=1.000 n=10) ¹
¹ all samples are equal

.fullname: Fair/get-chaotic-flavor|get-8
                              │   old.txt   │              new.txt               │
                              │   sec/op    │   sec/op     vs base               │
Fair/get-chaotic-flavor|get-8   5.104µ ± 0%   5.015µ ± 0%  -1.75% (p=0.000 n=10)

                              │   old.txt    │               new.txt               │
                              │     B/s      │     B/s       vs base               │
Fair/get-chaotic-flavor|get-8   7.581Gi ± 0%   7.717Gi ± 1%  +1.79% (p=0.000 n=10)

                              │   old.txt    │             new.txt              │
                              │     B/op     │     B/op      vs base            │
Fair/get-chaotic-flavor|get-8   4.443Ki ± 0%   4.443Ki ± 0%  ~ (p=1.000 n=10) ¹
¹ all samples are equal

                              │  old.txt   │            new.txt             │
                              │ allocs/op  │ allocs/op   vs base            │
Fair/get-chaotic-flavor|get-8   168.0 ± 0%   168.0 ± 0%  ~ (p=1.000 n=10) ¹
¹ all samples are equal
```
